### PR TITLE
Create display to help tune metrics

### DIFF
--- a/display/dataserv.go
+++ b/display/dataserv.go
@@ -1,0 +1,48 @@
+package monteverdi
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func (v *View) metricsDataHandler(w http.ResponseWriter, r *http.Request) {
+	v.QNet.MU.RLock()
+	defer v.QNet.MU.RUnlock()
+
+	type MetricData struct {
+		Endpoint    string  `json:"endpoint"`
+		Metric      string  `json:"metric"`
+		CurrentVal  int64   `json:"currentVal"`
+		MaxVal      int64   `json:"maxVal"`
+		IsAccent    bool    `json:"isAccent"`
+		PercentUsed float64 `json:"percentUsed"`
+	}
+
+	var allMetrics []MetricData
+
+	for _, ep := range v.QNet.Network {
+		ep.MU.RLock()
+		for _, metricName := range ep.Metric {
+			currentVal := ep.Mdata[metricName]
+			maxVal := ep.Maxval[metricName]
+			isAccent := currentVal >= maxVal
+			percentUsed := 0.0
+			if maxVal > 0 {
+				percentUsed = (float64(currentVal) / float64(maxVal)) * 100
+			}
+
+			allMetrics = append(allMetrics, MetricData{
+				Endpoint:    ep.ID,
+				Metric:      metricName,
+				CurrentVal:  currentVal,
+				MaxVal:      maxVal,
+				IsAccent:    isAccent,
+				PercentUsed: percentUsed,
+			})
+		}
+		ep.MU.RUnlock()
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(allMetrics)
+}

--- a/display/websocket.go
+++ b/display/websocket.go
@@ -256,13 +256,21 @@ func (v *View) CalcSpeedForPulse(pe Ms.PulseEvent) float64 {
 	return CalcSpeed(pe.StartTime, config)
 }
 
+var Version = "dev"
+
+func (v *View) versionHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"version": Version})
+}
+
 // Mux handles both Prometheus metrics and WebSocket data delivery
 func (v *View) setupMux() *mux.Router {
 	r := mux.NewRouter()
 
 	r.Handle("/metrics", v.stats.Handler())
 	r.HandleFunc("/ws", v.websocketHandler)
-	r.HandleFunc("/api/version", v.versionHandler) // Add this line
+	r.HandleFunc("/api/version", v.versionHandler)
+	r.HandleFunc("/api/metrics-data", v.metricsDataHandler)
 
 	// Static files for D3 frontend
 	r.PathPrefix("/").Handler(http.FileServer(http.Dir("./web/")))
@@ -271,11 +279,4 @@ func (v *View) setupMux() *mux.Router {
 	api.Use(v.statsMiddleware)
 
 	return r
-}
-
-var Version = "dev"
-
-func (v *View) versionHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"version": Version})
 }

--- a/example_config.json
+++ b/example_config.json
@@ -3,15 +3,9 @@
     "id": "NETDATA",
     "url": "http://localhost:19999/api/v3/allmetrics",
     "delim": "=",
-    "metrics": {
-      "NETDATA_APP_WINDOWSERVER_CPU_UTILIZATION_VISIBLETOTAL": {
-        "type": "gauge",
-        "max": 20
-      },
-      "NETDATA_IPV4_PACKETS_VISIBLETOTAL": {
-        "type": "rate",
-        "max": 30
-      }
+    "metrics": { "NETDATA_APP_WINDOWSERVER_CPU_UTILIZATION_VISIBLETOTAL": { "type": "gauge", "max": 20 },
+      "NETDATA_USER_MATT_CPU_UTILIZATION_VISIBLETOTAL": { "type": "rate", "max": 90 },
+      "NETDATA_IPV4_PACKETS_VISIBLETOTAL": { "type": "rate", "max": 30 }
     }
   },
   {
@@ -19,26 +13,16 @@
     "url": "http://verificat.rainbowq.net:4330/metrics",
     "delim": " ",
     "metrics": {
-      "process_network_receive_bytes_total": {
-        "type": "counter",
-        "transformer": "calc_rate",
-        "max": 400
-      },
-      "process_network_transmit_bytes_total": {
-        "type": "counter",
-        "transformer": "calc_rate",
-        "max": 2700
-      },
-      "go_memstats_alloc_bytes_total": {
-        "type": "counter",
-        "transformer": "calc_rate",
-        "max": 145000
-      },
-      "http_requests_inbound_total{code=\"200\",method=\"GET:/healthz\"}": {
-        "type": "counter",
-        "transformer": "calc_rate",
-        "max": 1
-      }
+      "process_network_receive_bytes_total": { "type": "counter", "transformer": "calc_rate", "max": 400 },
+      "process_network_transmit_bytes_total": { "type": "counter", "transformer": "calc_rate", "max": 2700 },
+      "process_resident_memory_bytes": { "type": "gauge", "max": 30000000 },
+      "go_memstats_heap_alloc_bytes": { "type": "gauge", "max": 30000000 },
+      "go_memstats_heap_inuse_bytes": { "type": "gauge", "max": 8000000 },
+      "go_gc_heap_objects_objects": { "type": "gauge", "max": 44000 },
+      "go_memstats_alloc_bytes_total": { "type": "counter", "transformer": "calc_rate", "max": 20000000 },
+      "go_goroutines": { "type": "counter", "transformer": "calc_rate", "max": 1 },
+      "process_open_fds": { "type": "counter", "transformer": "calc_rate", "max": 1 },
+      "http_requests_inbound_total{code=\"200\",method=\"GET:/healthz\"}": { "type": "counter", "transformer": "calc_rate", "max": 1 }
     }
   },
   {
@@ -46,19 +30,13 @@
     "url": "http://localhost:8090/metrics",
     "delim": " ",
     "metrics": {
-      "process_resident_memory_bytes": {
-        "type": "gauge",
-        "max": 30000000
-      },
-      "go_memstats_heap_inuse_bytes": {
-        "type": "gauge",
-        "max": 8000000
-      },
-      "go_memstats_alloc_bytes_total": {
-        "type": "counter",
-        "transformer": "calc_rate",
-        "max": 20000000
+      "process_resident_memory_bytes": { "type": "gauge", "max": 30000000 },
+      "go_memstats_heap_alloc_bytes": { "type": "gauge", "max": 30000000 },
+      "go_memstats_heap_inuse_bytes": { "type": "gauge", "max": 8000000 },
+      "go_gc_heap_objects_objects": { "type": "gauge", "max": 44000 },
+      "go_memstats_alloc_bytes_total": { "type": "counter", "transformer": "calc_rate", "max": 20000000 },
+      "go_goroutines": { "type": "counter", "transformer": "calc_rate", "max": 1 },
+      "process_open_fds": { "type": "counter", "transformer": "calc_rate", "max": 1 }
       }
     }
-  }
 ]

--- a/web/index.html
+++ b/web/index.html
@@ -9,10 +9,10 @@
 <body>
 
 <div id="container">
-    <div id="introTooltip" class="intro-tooltip" style="text-align: center">
+    <!--div id="introTooltip" class="intro-tooltip" style="text-align: center">
         <strong>Seconda Practica<br>Observability</strong><br>
         Hover over UI elements to get started.
-    </div>
+    </div-->
 
     <h1>Monteverdi</h1>
     <div style="position: relative; width: 500px; margin: 0 auto;">
@@ -29,6 +29,13 @@
         <!-- Main chart (overlays on top) -->
         <svg id="chart"></svg>
     </div>
+
+    <div style="text-align: center; margin-bottom: 10px;">
+        <a href="/metrics-data.html" style="color: #5fa73b; text-decoration: none; font-size: 14px; font-weight: bold;">
+            Tuning Raw Metrics Data →
+        </a>
+    </div>
+
 </div>
 
 <div id="controls" style="

--- a/web/metrics-data.css
+++ b/web/metrics-data.css
@@ -1,0 +1,102 @@
+/* metrics.css - Styles for the metrics data page */
+
+#metrics-panel {
+    margin-top: 20px;
+    padding: 15px;
+    background: rgba(45,45,45,0.8);
+    border-radius: 8px;
+    border: 1px solid #555;
+}
+
+#metrics-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+
+#metrics-table thead tr {
+    border-bottom: 2px solid #555;
+}
+
+#metrics-table th {
+    text-align: left;
+    padding: 8px;
+    color: #e85ff8;
+    font-weight: bold;
+    position: sticky;
+    top: 0;
+    background: #2d2d2d;
+}
+
+#metrics-table th:nth-child(3),
+#metrics-table th:nth-child(4),
+#metrics-table th:nth-child(5) {
+    text-align: right;
+}
+
+#metrics-table th:nth-child(6) {
+    text-align: center;
+}
+
+#metrics-table tbody tr {
+    border-bottom: 1px solid #333;
+}
+
+#metrics-table tbody tr:hover {
+    background-color: #2a2a2a;
+}
+
+.nav-link {
+    display: inline-block;
+    margin: 10px 0;
+    color: #5fa73b;
+    text-decoration: none;
+    font-size: 14px;
+}
+
+.nav-link:hover {
+    color: #7fc95f;
+}
+
+a:visited {
+    color: #5fa73b;
+}
+
+a:visited:hover {
+    color: #7fc95f;
+}
+
+.help-section {
+    margin-top: 20px;
+    padding: 15px;
+    background: rgba(45,45,45,0.5);
+    border-radius: 8px;
+    font-size: 13px;
+    color: #aaa;
+}
+
+.help-section h4 {
+    color: #e85ff8;
+    margin-top: 0;
+}
+
+.help-section ol {
+    line-height: 1.8;
+}
+
+.help-section strong {
+    color: #00fce7;
+}
+
+.help-section code {
+    background: #1e1e1e;
+    padding: 2px 6px;
+    border-radius: 3px;
+    color: #ff7f00;
+    font-family: 'Courier New', monospace;
+}
+
+.help-section p {
+    margin: 10px 0 0 0;
+    font-style: italic;
+}

--- a/web/metrics-data.html
+++ b/web/metrics-data.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Monteverdi - Metrics Data</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="metrics-data.css">
+</head>
+<body>
+
+<div id="container">
+    <h1>Monteverdi <span style="font-size: 0.5em; color: #888;" id="version"></span></h1>
+
+    <div style="margin-top: 20px; padding: 15px; background: rgba(45,45,45,0.5); border-radius: 8px; font-size: 13px; color: #aaa;">
+        <h4 style="color: #e85ff8; margin-top: 0;">How to tune your config.json:</h4>
+        <ol style="line-height: 1.8;">
+            <li>Watch the <strong style="color: #00fce7;">Current</strong> values to see typical ranges for your metrics</li>
+            <li>The <strong style="color: #ffcc00;">% Used</strong> shows how close you are to triggering an accent</li>
+            <li>When <strong style="color: #ff7f00;">? 🔥</strong> appears, that metric has exceeded its maxval threshold</li>
+            <li>Adjust the <code>"metrics"</code> values in <code>config.json</code> to set appropriate thresholds</li>
+            <li>Restart Monteverdi to apply changes</li>
+        </ol>
+        <p style="margin: 10px 0 0 0; font-style: italic;">
+            Tip: Set maxval slightly above normal peaks to avoid false positives, but low enough to catch real issues.
+        </p>
+    </div>
+
+    <div class="nav-link">
+            <a href="/" style="font-size: 14px; font-weight: bold;">
+            ← Back to Radar View
+        </a>
+    </div>
+
+
+    <div id="metrics-panel">
+        <h3 style="color: #5fa73b; margin-top: 0;">
+            Current Metric Values
+            <span style="font-size: 0.6em; color: #888;">(for tuning maxval in config.json)</span>
+        </h3>
+        <div id="metrics-table-container">
+            <table id="metrics-table">
+                <thead>
+                <tr>
+                    <th>Endpoint</th>
+                    <th>Metric</th>
+                    <th>Current</th>
+                    <th>Max</th>
+                    <th>% Used</th>
+                    <th>?</th>
+                </tr>
+                </thead>
+                <tbody id="metrics-tbody">
+                <!-- Populated by JS -->
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+</div>
+
+<script src="metrics-data.js"></script>
+<script>
+    // Fetch version
+    fetch('/api/version')
+        .then(r => r.json())
+        .then(data => {
+            document.getElementById('version').textContent = data.version;
+        })
+        .catch(err => console.log('Version fetch failed:', err));
+</script>
+</body>
+</html>

--- a/web/metrics-data.js
+++ b/web/metrics-data.js
@@ -1,0 +1,73 @@
+// metrics.js - Handle the live metrics table display
+
+// Fetch and display current metric values
+function updateMetricsTable() {
+    fetch('/api/metrics-data')
+        .then(r => r.json())
+        .then(data => {
+            const tbody = document.getElementById('metrics-tbody');
+            tbody.innerHTML = '';
+
+            data.forEach(metric => {
+                const row = tbody.insertRow();
+
+                // Endpoint
+                row.insertCell().textContent = metric.endpoint;
+
+                // Metric name
+                const metricCell = row.insertCell();
+                metricCell.textContent = metric.metric;
+                metricCell.style.fontFamily = 'monospace';
+
+                // Current value
+                const currentCell = row.insertCell();
+                currentCell.textContent = metric.currentVal.toLocaleString();
+                currentCell.style.textAlign = 'right';
+                currentCell.style.fontFamily = 'monospace';
+                currentCell.style.color = metric.isAccent ? '#00fce7' : '#aaa';
+
+                // Max value
+                const maxCell = row.insertCell();
+                maxCell.textContent = metric.maxVal.toLocaleString();
+                maxCell.style.textAlign = 'right';
+                maxCell.style.fontFamily = 'monospace';
+
+                // Percentage
+                const pctCell = row.insertCell();
+                pctCell.textContent = metric.percentUsed.toFixed(1) + '%';
+                pctCell.style.textAlign = 'right';
+                pctCell.style.fontFamily = 'monospace';
+
+                // Color code the percentage
+                if (metric.percentUsed >= 100) {
+                    pctCell.style.color = '#ff7f00'; // Orange - accent triggered
+                } else if (metric.percentUsed >= 80) {
+                    pctCell.style.color = '#ffcc00'; // Yellow - getting close
+                } else {
+                    pctCell.style.color = '#5fa73b'; // Green - normal
+                }
+
+                // Status indicator
+                const statusCell = row.insertCell();
+                statusCell.style.textAlign = 'center';
+                if (metric.isAccent) {
+                    statusCell.innerHTML = '🔥';
+                    statusCell.title = 'Accent triggered!';
+                } else {
+                    statusCell.innerHTML = '✓';
+                    statusCell.style.color = '#5fa73b';
+                }
+
+                // Style the row
+                row.style.borderBottom = '1px solid #333';
+                Array.from(row.cells).forEach(cell => {
+                    cell.style.padding = '8px';
+                });
+            });
+        })
+        .catch(err => console.error('Failed to fetch metrics:', err));
+}
+
+// Update table every 2 seconds
+setInterval(updateMetricsTable, 2000);
+updateMetricsTable(); // Initial load


### PR DESCRIPTION
Containers in Monteverdi do not display the useful TUI that shows raw values for tuning the config. This change adds a new page linked from the front radar where users can see their metrics with raw values and other trending to decide how to set their max value for triggering.