### PR TITLE
jsonkey-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.test
 
 # local files
+*/*_db
 .env
 /monteverdi
 /monteverdi_db/

--- a/.idea/monteverdi.iml
+++ b/.idea/monteverdi.iml
@@ -5,6 +5,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/dist" />
       <excludeFolder url="file://$MODULE_DIR$/monteverdi_db" />
+      <excludeFolder url="file://$MODULE_DIR$/plugin/badger_db" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/config.json
+++ b/config.json
@@ -1,22 +1,33 @@
 [
-    {
-        "id": "MONTEVERDI_INTERNAL",
-        "url": "http://localhost:8090/metrics",
-        "delim": " ",
-        "metrics": {
-            "process_resident_memory_bytes": {
-                "type": "gauge",
-                "max": 30000000
-            },
-            "go_memstats_heap_inuse_bytes": {
-                "type": "gauge",
-                "max": 8000000
-            },
-            "go_memstats_alloc_bytes_total": {
-                "type": "counter",
-                "transformer": "calc_rate",
-                "max": 20000000
-            }
-        }
+  {
+    "id": "NETDATA",
+    "url": "http://localhost:19999/api/v3/allmetrics",
+    "delim": "=",
+    "metrics": { "NETDATA_APP_WINDOWSERVER_CPU_UTILIZATION_VISIBLETOTAL": { "type": "gauge", "max": 20 },
+      "NETDATA_USER_MATT_CPU_UTILIZATION_VISIBLETOTAL": { "type": "rate", "max": 90 },
+      "NETDATA_IPV4_PACKETS_VISIBLETOTAL": { "type": "rate", "max": 30 }
+    }
+  },
+  {
+    "id": "COINGECKO",
+    "url": "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd",
+    "delim": "",
+    "metrics": {
+      "bitcoin.usd": { "type": "gauge", "transformer": "json_key", "max": 113000 }
+    }
+  },
+  {
+    "id": "MONTEVERDI_INTERNAL",
+    "url": "http://localhost:8090/metrics",
+    "delim": " ",
+    "metrics": {
+      "process_resident_memory_bytes": { "type": "gauge", "max": 54000000 },
+      "go_memstats_heap_alloc_bytes": { "type": "gauge", "max": 30000000 },
+      "go_memstats_heap_inuse_bytes": { "type": "gauge", "max": 80000000 },
+      "go_gc_heap_objects_objects": { "type": "gauge", "max": 44000 },
+      "go_memstats_alloc_bytes_total": { "type": "counter", "transformer": "calc_rate", "max": 20000000 },
+      "go_goroutines": { "type": "counter", "transformer": "calc_rate", "max": 1 },
+      "process_open_fds": { "type": "counter", "transformer": "calc_rate", "max": 1 }
+      }
     }
 ]

--- a/plugin/outputs-badger_test.go
+++ b/plugin/outputs-badger_test.go
@@ -24,7 +24,7 @@ func TestNewBadgerOutput(t *testing.T) {
 	defer closedb()
 
 	t.Run("Creates new struct for output", func(t *testing.T) {
-		path := "./badger.db"
+		path := "./badger_db"
 		got, err := Mp.NewBadgerOutput(path, 10)
 		assertError(t, err, nil)
 		assertInt(t, got.BatchSize, compare.batchSize)

--- a/plugin/transform-json.go
+++ b/plugin/transform-json.go
@@ -31,6 +31,7 @@ func NewJSONTransformer(mk string) *JSONKeyPlugin {
 // held as the full 'metric', i.e. the entire JSON response from ParseMetricKV
 func (tj *JSONKeyPlugin) Transform(metric string, current int64, historical []int64, timestamp time.Time) (int64, error) {
 
+	// Unmarshal the JSON into an interface for extraction
 	var data interface{}
 	if err := json.Unmarshal([]byte(metric), &data); err != nil {
 		slog.Error("Error unmarshalling json",
@@ -48,6 +49,8 @@ func (tj *JSONKeyPlugin) Transform(metric string, current int64, historical []in
 	return value, nil
 }
 
+// ExtractValue takes an interface that is assumed to have JSON data
+// and extract the specific metric key defined as a JSON path
 func ExtractValue(data interface{}, metric string) (int64, error) {
 	keys := strings.Split(metric, ".")
 	current := data

--- a/plugin/transform-json.go
+++ b/plugin/transform-json.go
@@ -68,25 +68,13 @@ func ExtractValue(data interface{}, metric string) (int64, error) {
 	}
 
 	// Convert final value to int64
+	// json.Unmarshal loads all numbers as float64
+	// so it's the only real case to catch
 	switch v := current.(type) {
 	case float64:
 		return int64(v), nil
-	case int64:
-		return v, nil
-	case int:
-		return int64(v), nil
-	case json.Number:
-		i, err := v.Int64()
-		if err != nil {
-			f, err := v.Float64()
-			if err != nil {
-				return 0, fmt.Errorf("error converting json.Number to int64: %v", err)
-			}
-			return int64(f), nil
-		}
-		return i, nil
 	default:
-		return 0, fmt.Errorf("value not numeric, cannot traverse %T", v)
+		return 0, fmt.Errorf("unexpected non-numeric: %T", v)
 	}
 }
 

--- a/plugin/transform-json.go
+++ b/plugin/transform-json.go
@@ -1,0 +1,94 @@
+package plugin
+
+/*
+	JSONKey
+
+	This plugin allows for JSON to be used as the metric data.
+
+	Returns a positive integer from the value of a key inside a JSON object
+
+	This expects the /metric/ used by Transform to contain the entire JSON
+*/
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+type JSONKeyPlugin struct {
+	MetricKey string
+}
+
+// NewJSONTransformer returns a struct for what to search in the JSON
+func NewJSONTransformer(mk string) *JSONKeyPlugin {
+	return &JSONKeyPlugin{MetricKey: mk}
+}
+
+// Transform extracts the JSONKeyPlugin key from the JSON object
+// held as the full 'metric', i.e. the entire JSON response from ParseMetricKV
+func (tj *JSONKeyPlugin) Transform(metric string, current int64, historical []int64, timestamp time.Time) (int64, error) {
+
+	var data interface{}
+	if err := json.Unmarshal([]byte(metric), &data); err != nil {
+		slog.Error("Error unmarshalling json",
+			slog.String("search", tj.MetricKey),
+			slog.String("json", metric),
+			slog.Any("error", err))
+		return 0, fmt.Errorf("error unmarshalling json from metric: %v", err)
+	}
+
+	value, err := ExtractValue(data, tj.MetricKey)
+	if err != nil {
+		return 0, fmt.Errorf("error extracting json value from metric: %v", err)
+	}
+
+	return value, nil
+}
+
+func ExtractValue(data interface{}, metric string) (int64, error) {
+	keys := strings.Split(metric, ".")
+	current := data
+
+	for _, key := range keys {
+		switch v := current.(type) {
+		case map[string]interface{}:
+			var ok bool
+			current, ok = v[key]
+			if !ok {
+				return 0, fmt.Errorf("key %s not found", key)
+			}
+		case []interface{}:
+			return 0, fmt.Errorf("array indexing not implemented yet")
+		default:
+			return 0, fmt.Errorf("cannot traverse into type %T at key %s", v, key)
+		}
+	}
+
+	// Convert final value to int64
+	switch v := current.(type) {
+	case float64:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case int:
+		return int64(v), nil
+	case json.Number:
+		i, err := v.Int64()
+		if err != nil {
+			f, err := v.Float64()
+			if err != nil {
+				return 0, fmt.Errorf("error converting json.Number to int64: %v", err)
+			}
+			return int64(f), nil
+		}
+		return i, nil
+	default:
+		return 0, fmt.Errorf("value not numeric, cannot traverse %T", v)
+	}
+}
+
+func (tj *JSONKeyPlugin) HysteresisReq() int { return -1 } // Not applicable
+func (tj *JSONKeyPlugin) Type() string       { return "json_key" }

--- a/plugin/transform-json_test.go
+++ b/plugin/transform-json_test.go
@@ -1,0 +1,93 @@
+package plugin_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	Mp "github.com/maroda/monteverdi/plugin"
+)
+
+func TestNewJSONTransformer(t *testing.T) {
+	t.Run("Returns JSON transformer", func(t *testing.T) {
+		key := "NETWORK"
+
+		newJSON := Mp.NewJSONTransformer(key)
+		assertStringContains(t, newJSON.MetricKey, key)
+	})
+}
+
+func TestJSONKeyPlugin(t *testing.T) {
+	t.Run("HysteresisReq returns the correct value", func(t *testing.T) {
+		// Hysteresis in JSONKey is meaningless so set it to -1
+		plugin := Mp.JSONKeyPlugin{}
+		want := -1
+		got := plugin.HysteresisReq()
+		assertInt(t, got, want)
+	})
+
+	t.Run("Type returns the correct value", func(t *testing.T) {
+		plugin := Mp.JSONKeyPlugin{}
+		want := "json_key"
+		got := plugin.Type()
+		assertStringContains(t, got, want)
+	})
+
+	t.Run("Metric returns the correct value", func(t *testing.T) {
+		// This interface expects that /metric/ is filled with JSON
+		now := time.Now()
+		metric := `{"bitcoin":{"usd":111580},"ethereum":{"usd":3955.02}}`
+		want := int64(111580)
+		plugin := Mp.JSONKeyPlugin{
+			MetricKey: "bitcoin.usd",
+		}
+
+		got, err := plugin.Transform(metric, 0, []int64{0}, now)
+		assertError(t, err, nil)
+		assertInt64(t, got, want)
+	})
+}
+
+func TestJSONKeyPlugin_Live(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live test in short mode")
+	}
+
+	t.Run("INTEGRATION: coingecko response in real-time", func(t *testing.T) {
+		now := time.Now()
+		webclient := http.Client{}
+		url := "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum&vs_currencies=usd"
+		resp, err := webclient.Get(url)
+		assertError(t, err, nil)
+		body, err := io.ReadAll(resp.Body)
+		defer resp.Body.Close()
+
+		// Get the value here in the test first
+		var response CryptoResponse
+		err = json.Unmarshal(body, &response)
+		assertError(t, err, nil)
+
+		// Now create a new interface with the value we want
+		plugin := Mp.JSONKeyPlugin{
+			MetricKey: "ethereum.usd",
+		}
+
+		// Plug that into the Transform method and the values should match
+		got, err := plugin.Transform(string(body), 0, []int64{0}, now)
+		assertError(t, err, nil)
+		assertInt64(t, got, int64(response.Ethereum.USD))
+	})
+}
+
+// Helpers //
+
+type CryptoResponse struct {
+	Bitcoin  Currency `json:"bitcoin"`
+	Ethereum Currency `json:"ethereum"`
+}
+
+type Currency struct {
+	USD float64 `json:"usd"`
+}

--- a/server/plugin-badgerdb_test.go
+++ b/server/plugin-badgerdb_test.go
@@ -48,7 +48,7 @@ func TestQNet_PulseDetectWriteBadgerDB(t *testing.T) {
 
 	t.Run("Writes values to BadgerDB during PulseDetect", func(t *testing.T) {
 		// Define BadgerOutput adapter
-		path := "./badger.db"
+		path := "./badger_db"
 		batchSize := 1
 		output, err := Mp.NewBadgerOutput(path, batchSize)
 		defer output.Close()

--- a/server/plugin-jsonkey_test.go
+++ b/server/plugin-jsonkey_test.go
@@ -1,0 +1,86 @@
+package monteverdi_test
+
+import (
+	"testing"
+	"time"
+
+	Mp "github.com/maroda/monteverdi/plugin"
+	Ms "github.com/maroda/monteverdi/server"
+	Mt "github.com/maroda/monteverdi/types"
+)
+
+func TestQNet_PollMulti_JSONKeyPlugin(t *testing.T) {
+	testMetric := "bitcoin.usd"
+	remotebody := `{"bitcoin":{"usd":111580},"ethereum":{"usd":3955.02}}`
+	mockWWW := makeMockWebServBody(0*time.Millisecond, remotebody)
+	ep := &Ms.Endpoint{
+		ID:     "test",
+		URL:    mockWWW.URL,
+		Delim:  "",
+		Metric: map[int]string{1: testMetric},
+		Mdata:  make(map[string]int64),
+		Maxval: map[string]int64{testMetric: 111600},
+		Accent: make(map[string]*Mt.Accent),
+		Layer: map[string]*Mt.Timeseries{
+			testMetric: {
+				Runes:   make([]rune, 80),
+				MaxSize: 80,
+				Current: 0,
+			},
+		},
+		Sequence: make(map[string]*Ms.IctusSequence),
+		Pulses: &Ms.TemporalGrouper{
+			WindowSize: 60 * time.Second,
+			Buffer:     make([]Mt.PulseEvent, 0),
+			Groups:     make([]*Mt.PulseTree, 0),
+		},
+		Hysteresis:   make(map[string]*Ms.CycBuffer),
+		Transformers: map[string]Mp.MetricTransformer{testMetric: &Mp.JSONKeyPlugin{testMetric}},
+	}
+	eps := Ms.Endpoints{ep}
+	qn := Ms.NewQNet(eps)
+
+	t.Run("Correctly fetches value from JSON", func(t *testing.T) {
+		qn.PollMulti()
+		got := qn.Network[0].Mdata["bitcoin.usd"]
+		want := int64(111580)
+		assertInt64(t, got, want)
+	})
+
+	// Close mock server for error tests
+	mockWWW.Close()
+
+	t.Run("Continues when fetch fails", func(t *testing.T) {
+		qn.PollMulti()
+		// This passes if we get this far without panic
+	})
+}
+
+func TestNewEndpointsFromConfig_JSONKeyPlugin(t *testing.T) {
+	configFile, delConfig := createTempFile(t, `[{
+  "id": "COINGECKO",
+  "url": "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd",
+  "delim": "",
+  "metrics": {
+    "bitcoin.usd": {
+      "type": "gauge",
+      "transformer": "json_key",
+      "max": 111000
+    }
+  }
+		}]`)
+	defer delConfig()
+	fileName := configFile.Name()
+
+	loadConfig, err := Ms.LoadConfigFileName(fileName)
+	assertError(t, err, nil)
+
+	eps := Ms.NewEndpointsFromConfig(loadConfig)
+
+	t.Run("Transformer is returned", func(t *testing.T) {
+		ep := (*eps)[0]
+		if ep.Transformers["bitcoin.usd"] == nil {
+			t.Error("No Transformer returned for metric")
+		}
+	})
+}

--- a/server/poller.go
+++ b/server/poller.go
@@ -77,6 +77,7 @@ func MetricKV(d, url string) (map[string]string, error) {
 	return ParseMetricKV(bytes.NewReader(body), d)
 }
 
+// ParseMetricKV pairs with MetricKV to extract all configured metrics from an endpoint
 func ParseMetricKV(reader io.Reader, d string) (map[string]string, error) {
 	envMap := make(map[string]string)
 	scanner := bufio.NewScanner(reader)


### PR DESCRIPTION
Basic functionality to support JSON on endpoints for extracting keys at certain paths.

For instance, the path 'bitcoin.usd' is the entire key name, and the full contents of the Endpoint is used as the blob from which to extract the key value.

This work uncovered the need for separate Endpoint polling intervals that will be covered in a future PR.