### PR TITLE
midi-outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ To retrieve the current configuration: `curl http://localhost:8090/conf`
 
 ### Runtime
 
-Refer to the command help for any special configurations you want to make. The options and environment variables are listed:
+Refer to the command help for any special configurations you wantNotes to make. The options and environment variables are listed:
 ```shell
 >>> ./monteverdi -help
 Monteverdi - Seconda Practica Observability

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ An endpoint is any URL that serves K/V data (delimiter is configurable), for ins
 
 ### Active Plugins
 
-- Setting `MONTEVERDI_OUTPUT` to a file path will run the BadgerDB output adapter. This writes the stream of pulses to the database for archiving.
+- Setting `MONTEVERDI_OUTPUT` to **a file path** will run the BadgerDB output adapter. This writes the stream of pulses to the database for archiving.
+- Setting `MONTEVERDI_OUTPUT` to **"MIDI"** will run the MIDI output adapter. It assumes there is a connected MIDI interface with a device receiving messages.
 - Configure the `calc_rate` transformer to ingest counting metrics as a rate.
 - Configure the `json_key` transformer to read an endpoint and extract data from a JSON blob.
 
@@ -256,5 +257,3 @@ spec:
 - Metrics input. Can read an existing timeseries with KV and extract pulses.
 - Inference. How do we take a history of pulses and define expected behaviors?
 - Monitor. How do we "alert" on pulse diversion?
-- Output. Can the pulses be converted to other formats?
-- Audio. How do the patterns sound?

--- a/display/terminal.go
+++ b/display/terminal.go
@@ -748,6 +748,7 @@ func StartHarmonyView(c []Ms.ConfigFile, path string) error {
 
 	// Configure output if set
 	// For now, assume BadgerDB
+	// TODO: create QNet method to set this
 	outputLocation := Ms.FillEnvVar("MONTEVERDI_OUTPUT")
 	if outputLocation != "ENOENT" {
 		batchSize := 100

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,8 @@ require (
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.8.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	gitlab.com/gomidi/midi v1.23.7 // indirect
+	gitlab.com/gomidi/midi/v2 v2.3.16 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/host v0.53.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.53.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,10 @@ github.com/tklauser/numcpus v0.8.0/go.mod h1:ZJZlAY+dmR4eut8epnzf0u/VwodKmryxR8t
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+gitlab.com/gomidi/midi v1.23.7 h1:I6qKoIk9s9dcX+pNf0jC+tziCzJFn82bMpuntRkLeik=
+gitlab.com/gomidi/midi v1.23.7/go.mod h1:3ohtNOhqoSakkuLG/Li1OI6I3J1c2LErnJF5o/VBq1c=
+gitlab.com/gomidi/midi/v2 v2.3.16 h1:yufWSENyjnJ4LFQa9BerzUm4E4aLfTyzw5nmnCteO0c=
+gitlab.com/gomidi/midi/v2 v2.3.16/go.mod h1:jDpP4O4skYi+7iVwt6Zyp18bd2M4hkjtMuw2cmgKgfw=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/detectors/aws/lambda v0.53.0 h1:KG6fOUk3EwSH1dEpsAbsLKFbn3cFwN9xDu8plGu55zI=

--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func main() {
 		panic("Error starting harmony view")
 	}
 
-	<-ctx.Done()
+	<-ctx.Done() // Graceful, hopefully
 	slog.Info("Shutting down")
 	downCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/plugin/outputs-midi.go
+++ b/plugin/outputs-midi.go
@@ -1,0 +1,88 @@
+package plugin
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	Mt "github.com/maroda/monteverdi/types"
+	"gitlab.com/gomidi/midi/v2"
+	"gitlab.com/gomidi/midi/v2/drivers"
+	_ "gitlab.com/gomidi/midi/v2/drivers/rtmididrv"
+)
+
+type MIDIOutput struct {
+	Port drivers.Out
+	Send func(msg midi.Message) error
+	WG   sync.WaitGroup
+}
+
+func NewMIDIOutput(port int) (*MIDIOutput, error) {
+	out, err := midi.OutPort(port)
+	if err != nil {
+		slog.Error("Error opening MIDI port", slog.Int("port", port))
+		return nil, fmt.Errorf("error opening MIDI port: %q", err)
+	}
+
+	send, err := midi.SendTo(out)
+	if err != nil {
+		slog.Error("Error sending to MIDI port", slog.Int("port", port))
+		return nil, fmt.Errorf("error sending to MIDI port: %q", err)
+	}
+
+	initmidi := &MIDIOutput{
+		Port: out,
+		Send: send,
+		WG:   sync.WaitGroup{},
+	}
+
+	return initmidi, nil
+}
+
+func (mo *MIDIOutput) SendNoteOnMIDI(midic, midin, midiv uint8) error {
+	return mo.Send(midi.NoteOn(midic, midin, midiv))
+}
+
+func (mo *MIDIOutput) SendNoteOffMIDI(midic, midin uint8) error {
+	return mo.Send(midi.NoteOff(midic, midin))
+}
+
+func (mo *MIDIOutput) WritePulse(pulse *Mt.PulseEvent) error {
+	var channel, note, velocity uint8
+	channel = 0
+	note = uint8(pulse.Pattern + 60)
+	velocity = 100
+
+	mo.WG.Add(1)
+	go func() {
+		defer mo.WG.Done()
+		if err := mo.SendNoteOnMIDI(channel, note, velocity); err != nil {
+			slog.Error("NoteOn event failed")
+		}
+		duration := pulse.Duration
+		time.Sleep(duration)
+		if err := mo.SendNoteOffMIDI(channel, note); err != nil {
+			slog.Error("NoteOff event failed, attempting Flush")
+			mo.Flush()
+		}
+	}()
+
+	return nil
+}
+
+func (mo *MIDIOutput) Flush() error {
+	return mo.Send(midi.ControlChange(0, midi.AllNotesOff, midi.Off))
+}
+
+func (mo *MIDIOutput) Close() error {
+	mo.WG.Wait()
+
+	if mo.Port != nil {
+		mo.Port.Close()
+		midi.CloseDriver()
+	}
+	return nil
+}
+
+func (mo *MIDIOutput) Type() string { return "MIDI" }

--- a/plugin/outputs-midi.go
+++ b/plugin/outputs-midi.go
@@ -12,12 +12,22 @@ import (
 	_ "gitlab.com/gomidi/midi/v2/drivers/rtmididrv"
 )
 
+// MIDIOutput is a
 type MIDIOutput struct {
-	Port drivers.Out
-	Send func(msg midi.Message) error
-	WG   sync.WaitGroup
+	WG       sync.WaitGroup
+	Port     drivers.Out                    // standard driver type
+	Send     func(msg midi.Message) error   // any midi message
+	NoteOff  func(midic, midin uint8) error // e.g. for quantization and testing
+	Channel  uint8                          // MIDI Channel, 0-15
+	Root     uint8                          // Root MIDI note (C3 = 60)
+	Velocity uint8                          // MIDI note velocity (0-127)
+	Scale    []uint8                        // Scale Intervals starting from 0 (for Root)
+	ScIdx    int                            // Track Scale Index for interval interpolation
 }
 
+// NewMIDIOutput is the router for pulse to become MIDI note,
+// this is where the `rtmididrv` is initiated and devices connected.
+// This also contains metadata for the musical notes being played.
 func NewMIDIOutput(port int) (*MIDIOutput, error) {
 	out, err := midi.OutPort(port)
 	if err != nil {
@@ -31,38 +41,92 @@ func NewMIDIOutput(port int) (*MIDIOutput, error) {
 		return nil, fmt.Errorf("error sending to MIDI port: %q", err)
 	}
 
+	defaultRoot := uint8(60)
+	defaultVelocity := uint8(100)
+	defaultScale := []uint8{0, 2, 2, 1, 2, 2, 2, 1} // Diatonic major
+
 	initmidi := &MIDIOutput{
-		Port: out,
-		Send: send,
-		WG:   sync.WaitGroup{},
+		WG:       sync.WaitGroup{},
+		Port:     out,
+		Send:     send,
+		Channel:  0,
+		Root:     defaultRoot,
+		Velocity: defaultVelocity,
+		Scale:    defaultScale,
+		ScIdx:    0,
 	}
+	initmidi.NoteOff = initmidi.SendNoteOffMIDI
 
 	return initmidi, nil
 }
 
+// SendNoteOnMIDI is the bridge between WritePulse and MIDIOutput
 func (mo *MIDIOutput) SendNoteOnMIDI(midic, midin, midiv uint8) error {
 	return mo.Send(midi.NoteOn(midic, midin, midiv))
 }
 
+// SendNoteOffMIDI is used to stop the note
 func (mo *MIDIOutput) SendNoteOffMIDI(midic, midin uint8) error {
 	return mo.Send(midi.NoteOff(midic, midin))
 }
 
-func (mo *MIDIOutput) WritePulse(pulse *Mt.PulseEvent) error {
-	var channel, note, velocity uint8
-	channel = 0
-	note = uint8(pulse.Pattern + 60)
-	velocity = 100
+// ScaleStep takes a Root note and derives the next note value
+// based on a sequence of intervals defined in Scale.
+func (mo *MIDIOutput) ScaleStep(root uint8) uint8 {
+	// Build the note number by adding up all notes in the scale up to this index
+	notes := uint8(0)
+	for i := 0; i < len(mo.Scale); i++ {
+		notes = notes + mo.Scale[i] // Add the number of intervals at Scale[i]
+		if i == mo.ScIdx {          // When i reaches the Scale Index, that's the last note to add
+			break
+		}
+	}
 
+	// Prep the index for the next run
+	// This enables wrap-around of the notes in the defined interval series
+	// So to get something like two octaves, mo.Scale will need to be two octaves
+	if mo.ScIdx == len(mo.Scale)-1 {
+		// When the Scale Index has read all members of mo.Scale, reset to 0
+		// the next note will be the first note above the root
+		mo.ScIdx = 0
+	} else {
+		// Otherwise, increase
+		// the next note will be the next interval above the current note
+		mo.ScIdx++
+	}
+	slog.Debug("NEXT scaling step", slog.Int("step", mo.ScIdx))
+	slog.Debug("Root note", slog.Int("root", int(root)))
+	slog.Debug("Current note", slog.Int("notes", int(root+notes)))
+
+	return root + notes
+}
+
+// WritePulse takes one PulseEvent and translates it to a MIDI event
+func (mo *MIDIOutput) WritePulse(pulse *Mt.PulseEvent) error {
+	// ScaleStep takes the root note and returns the note to play.
+	// Each time it's called, it increases the interface index counter,
+	// so that the next note played will be the next note in the scale.
+	channel := mo.Channel
+	note := mo.Root
+	velocity := mo.Velocity
+
+	if nn := mo.ScaleStep(mo.Root); nn != 0 {
+		note = nn
+	}
+
+	if err := mo.SendNoteOnMIDI(channel, note, velocity); err != nil {
+		slog.Error("NoteOn event failed")
+		return fmt.Errorf("NoteOn event failed: %q", err)
+	}
+
+	// NoteOffMIDI is performed in a goroutine, which allows
+	// notes to be independently stacked.
 	mo.WG.Add(1)
 	go func() {
 		defer mo.WG.Done()
-		if err := mo.SendNoteOnMIDI(channel, note, velocity); err != nil {
-			slog.Error("NoteOn event failed")
-		}
 		duration := pulse.Duration
 		time.Sleep(duration)
-		if err := mo.SendNoteOffMIDI(channel, note); err != nil {
+		if err := mo.NoteOff(channel, note); err != nil {
 			slog.Error("NoteOff event failed, attempting Flush")
 			mo.Flush()
 		}
@@ -71,10 +135,13 @@ func (mo *MIDIOutput) WritePulse(pulse *Mt.PulseEvent) error {
 	return nil
 }
 
+// Flush sends an AllNotesOff to the active channel
+// TODO: that channel should be from the struct
 func (mo *MIDIOutput) Flush() error {
 	return mo.Send(midi.ControlChange(0, midi.AllNotesOff, midi.Off))
 }
 
+// Close will Wait until all NoteOff routines are completed and then close the device
 func (mo *MIDIOutput) Close() error {
 	mo.WG.Wait()
 
@@ -85,4 +152,5 @@ func (mo *MIDIOutput) Close() error {
 	return nil
 }
 
+// Type for this plugin
 func (mo *MIDIOutput) Type() string { return "MIDI" }

--- a/plugin/outputs-midi.go
+++ b/plugin/outputs-midi.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -10,6 +11,8 @@ import (
 	"gitlab.com/gomidi/midi/v2"
 	"gitlab.com/gomidi/midi/v2/drivers"
 	_ "gitlab.com/gomidi/midi/v2/drivers/rtmididrv"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // MIDIOutput is a
@@ -23,12 +26,23 @@ type MIDIOutput struct {
 	Velocity uint8                          // MIDI note velocity (0-127)
 	Scale    []uint8                        // Scale Intervals starting from 0 (for Root)
 	ScIdx    int                            // Track Scale Index for interval interpolation
+	ScNotes  []uint8                        // Notes computed from Root and Scale
+	IntSpace int                            // Build chords with WriteBatch using larger intervals
+	ArpSpace int                            // Build arpeggios with equal timing
+	QLimit   int                            // Quantize note limit for one beat
+	IsPoly   bool                           // Whether the MIDI output is polyphonic (false: monophonic)
+	Grouper  []*Mt.PulseEvent               // Grouper for chords or other entities
+	LastTS   time.Time                      // Most recent pulse timestamp
 }
 
 // NewMIDIOutput is the router for pulse to become MIDI note,
 // this is where the `rtmididrv` is initiated and devices connected.
 // This also contains metadata for the musical notes being played.
 func NewMIDIOutput(port int) (*MIDIOutput, error) {
+	ctx := context.Background()
+	ctx, span := otel.Tracer("monteverdi/plugin").Start(ctx, "NewMIDIOutput")
+	defer span.End()
+
 	out, err := midi.OutPort(port)
 	if err != nil {
 		slog.Error("Error opening MIDI port", slog.Int("port", port))
@@ -41,6 +55,7 @@ func NewMIDIOutput(port int) (*MIDIOutput, error) {
 		return nil, fmt.Errorf("error sending to MIDI port: %q", err)
 	}
 
+	defaultChannel := uint8(0)
 	defaultRoot := uint8(60)
 	defaultVelocity := uint8(100)
 	defaultScale := []uint8{0, 2, 2, 1, 2, 2, 2, 1} // Diatonic major
@@ -49,19 +64,65 @@ func NewMIDIOutput(port int) (*MIDIOutput, error) {
 		WG:       sync.WaitGroup{},
 		Port:     out,
 		Send:     send,
-		Channel:  0,
+		Channel:  defaultChannel,
 		Root:     defaultRoot,
 		Velocity: defaultVelocity,
 		Scale:    defaultScale,
 		ScIdx:    0,
+		IntSpace: 1,
+		ArpSpace: 300,
+		QLimit:   4,
+		IsPoly:   false,
+		Grouper:  []*Mt.PulseEvent{},
+		LastTS:   time.Now(),
 	}
 	initmidi.NoteOff = initmidi.SendNoteOffMIDI
+	initmidi.ScNotes = initmidi.ScaleNotes()
+
+	slog.Info("Created MIDI output",
+		slog.Any("available.ports", midi.GetOutPorts()),
+		slog.String("configured.port", initmidi.Port.String()),
+		slog.Int("send.channel", int(initmidi.Channel)),
+		slog.Int("root", int(initmidi.Root)),
+		slog.String("scale", fmt.Sprint(initmidi.Scale)),
+		slog.String("scale.notes", fmt.Sprint(initmidi.ScNotes)),
+	)
 
 	return initmidi, nil
 }
 
+// ScaleNotes returns the computed scale from Root plus Scale intervals
+// It will not overwrite any existing scale.f
+func (mo *MIDIOutput) ScaleNotes() []uint8 {
+	if mo.ScNotes == nil {
+		mo.ComputeScaleNotes()
+	}
+	return mo.ScNotes
+}
+
+// ComputeScaleNotes takes the configured Root and Scale
+// and builds the actual scale with MIDI notes starting from Root.
+func (mo *MIDIOutput) ComputeScaleNotes() {
+	note := uint8(0)       // Root Note
+	mo.ScNotes = []uint8{} // Empty Scale of (no) Notes
+	mo.ScIdx = 0           // Start with the first index (Root Note)
+
+	// Step through the Scale and build the Notes
+	for i := 0; i < len(mo.Scale); i++ {
+		// When nn is 0 we're starting on Root, so don't step
+		if nn := mo.ScaleStep(mo.Root); nn != 0 {
+			note = nn
+		}
+		mo.ScNotes = append(mo.ScNotes, note)
+	}
+}
+
 // SendNoteOnMIDI is the bridge between WritePulse and MIDIOutput
 func (mo *MIDIOutput) SendNoteOnMIDI(midic, midin, midiv uint8) error {
+	slog.Info("MIDI NoteOn",
+		slog.Int("note", int(midin)),
+		slog.Int("velocity", int(midiv)),
+		slog.Time("time", time.Now()))
 	return mo.Send(midi.NoteOn(midic, midin, midiv))
 }
 
@@ -101,44 +162,153 @@ func (mo *MIDIOutput) ScaleStep(root uint8) uint8 {
 	return root + notes
 }
 
-// WritePulse takes one PulseEvent and translates it to a MIDI event
-func (mo *MIDIOutput) WritePulse(pulse *Mt.PulseEvent) error {
-	// ScaleStep takes the root note and returns the note to play.
-	// Each time it's called, it increases the interface index counter,
-	// so that the next note played will be the next note in the scale.
-	channel := mo.Channel
-	note := mo.Root
-	velocity := mo.Velocity
+// WriteBatch builds a chord from closely timed pulses
+// and plays a stacked chord based on ScNotes.
+// When Polyphony is set with IsPoly it plays a chord,
+// and breaks it into an arpeggio in default Monophonic mode.
+func (mo *MIDIOutput) WriteBatch(pulses []*Mt.PulseEvent) error {
+	ctx := context.Background()
+	ctx, span := otel.Tracer("monteverdi/plugin").Start(ctx, "WriteBatch")
+	defer span.End()
 
-	if nn := mo.ScaleStep(mo.Root); nn != 0 {
-		note = nn
-	}
-
-	if err := mo.SendNoteOnMIDI(channel, note, velocity); err != nil {
-		slog.Error("NoteOn event failed")
-		return fmt.Errorf("NoteOn event failed: %q", err)
-	}
-
-	// NoteOffMIDI is performed in a goroutine, which allows
-	// notes to be independently stacked.
+	// The /range/ here will complete for each note within microseconds
+	// which should be fast enough to appear as a chord in MIDI
 	mo.WG.Add(1)
-	go func() {
+	go func() error {
 		defer mo.WG.Done()
-		duration := pulse.Duration
-		time.Sleep(duration)
-		if err := mo.NoteOff(channel, note); err != nil {
-			slog.Error("NoteOff event failed, attempting Flush")
-			mo.Flush()
+
+		for i, pulse := range pulses {
+			slog.Debug("Interval Spacing", slog.Int("space", mo.IntSpace))
+			noteIdx := (mo.IntSpace * i) % len(mo.ScNotes)
+			note := mo.ScNotes[noteIdx]
+
+			// If monophonic, space out the notes into an arpeggio
+			if !mo.IsPoly {
+				time.Sleep(time.Duration(mo.ArpSpace) * time.Millisecond)
+			}
+
+			if err := mo.SendNoteOnMIDI(mo.Channel, note, mo.Velocity); err != nil {
+				slog.Error("WriteBatch NoteOn event failed")
+				return fmt.Errorf("WriteBatch NoteOn event failed: %q", err)
+			}
+
+			mo.WG.Add(1)
+			go func(duration time.Duration) {
+				defer mo.WG.Done()
+
+				_, noteSpan := otel.Tracer("monteverdi/plugin").Start(ctx, "WriteBatch.NoteOff_goroutine")
+				defer noteSpan.End()
+
+				time.Sleep(duration)
+
+				if err := mo.NoteOff(mo.Channel, note); err != nil {
+					slog.Error("NoteOff event failed, attempting Flush")
+					mo.Flush()
+				}
+			}(pulse.Duration)
 		}
+		return nil
 	}()
 
 	return nil
 }
 
+type ChordGrouper struct {
+	WindowSize time.Duration
+	Buffer     []Mt.PulseEvent
+}
+
+// WritePulse takes one PulseEvent and translates it to a MIDI event
+func (mo *MIDIOutput) WritePulse(pulse *Mt.PulseEvent) error {
+	ctx := context.Background()
+	ctx, span := otel.Tracer("monteverdi/plugin").Start(ctx, "WritePulse")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("midi.output.port", mo.Port.String()),
+		attribute.Int("pulse.pattern", int(pulse.Pattern)),
+		attribute.Int64("pulse.duration_ms", pulse.Duration.Milliseconds()),
+	)
+
+	// This is initialized explicitly. If a note comes >50ms after
+	// the preceding note, it becomes the first qualifier for the next
+	// potential chord of notes within 50ms of each other, in other words
+	// it is added as the first member of the Grouper. First members
+	// must wait to see if the next note is under 50ms or not. Then
+	// the note is either played then (the next note is >50ms away)
+	// or saved for the chord (at which point there are 2 in the group).
+	var play bool
+	if len(mo.Grouper) == 0 {
+		// So do not play it immediately,
+		play = false
+	} else {
+		play = true
+	}
+
+	if len(mo.Grouper) > 0 && pulse.StartTime.Sub(mo.LastTS) < 50*time.Millisecond {
+		play = false
+		mo.Grouper = append(mo.Grouper, pulse)
+		slog.Info("Grouping pulse", slog.Int("pulse", len(mo.Grouper)))
+	} else {
+		// at this point the grouper is either 0 or the next note is not within 50ms
+		// this will not be reached until all simultaneous notes are added to the chord
+		if len(mo.Grouper) > 1 {
+			play = false
+			slog.Info("Playing batch")
+			if err := mo.WriteBatch(mo.Grouper); err != nil {
+				slog.Error("WriteBatch event failed", slog.Any("error", err))
+				return fmt.Errorf("WriteBatch failure: %q", err)
+			}
+		} else if len(mo.Grouper) == 1 {
+			slog.Info("Playing single")
+		}
+		// Reaching this far means a Grouper has been exhausted,
+		// the next note > 50ms was played,
+		// and so the current note is the first of the next potential chord
+		mo.Grouper = []*Mt.PulseEvent{pulse}
+	}
+
+	if play {
+		// ScaleStep takes the root note and returns the note to play.
+		// Each time it's called, it increases the interface index counter,
+		// so that the next note played will be the next note in the scale.
+		note := mo.Root
+		if nn := mo.ScaleStep(mo.Root); nn != 0 {
+			note = nn
+		}
+
+		if err := mo.SendNoteOnMIDI(mo.Channel, note, mo.Velocity); err != nil {
+			slog.Error("NoteOn event failed")
+			return fmt.Errorf("NoteOn event failed: %q", err)
+		}
+
+		// NoteOffMIDI is performed in a goroutine,
+		// allowing notes to be independently stacked.
+		mo.WG.Add(1)
+		go func(duration time.Duration) {
+			defer mo.WG.Done()
+
+			// The OTEL child span is set here for measuring the entire note event.
+			_, noteSpan := otel.Tracer("monteverdi/plugin").Start(ctx, "WritePulse.NoteOff_goroutine")
+			defer noteSpan.End()
+
+			time.Sleep(duration)
+
+			if err := mo.NoteOff(mo.Channel, note); err != nil {
+				slog.Error("NoteOff event failed, attempting Flush")
+				mo.Flush()
+			}
+		}(pulse.Duration)
+
+	}
+
+	mo.LastTS = pulse.StartTime
+	return nil
+}
+
 // Flush sends an AllNotesOff to the active channel
-// TODO: that channel should be from the struct
 func (mo *MIDIOutput) Flush() error {
-	return mo.Send(midi.ControlChange(0, midi.AllNotesOff, midi.Off))
+	return mo.Send(midi.ControlChange(mo.Channel, midi.AllNotesOff, midi.Off))
 }
 
 // Close will Wait until all NoteOff routines are completed and then close the device
@@ -156,9 +326,9 @@ func (mo *MIDIOutput) Close() error {
 func (mo *MIDIOutput) Type() string { return "MIDI" }
 
 // WriteBatch is Not Implemented
-func (mo *MIDIOutput) WriteBatch(pulses []*Mt.PulseEvent) error {
-	return fmt.Errorf("not implemented")
-}
+//func (mo *MIDIOutput) WriteBatch(pulses []*Mt.PulseEvent) error {
+//	return fmt.Errorf("not implemented")
+//}
 
 // QueryRange is Not Implemented
 func (mo *MIDIOutput) QueryRange(start, end time.Time) ([]*Mt.PulseEvent, error) {

--- a/plugin/outputs-midi.go
+++ b/plugin/outputs-midi.go
@@ -154,3 +154,13 @@ func (mo *MIDIOutput) Close() error {
 
 // Type for this plugin
 func (mo *MIDIOutput) Type() string { return "MIDI" }
+
+// WriteBatch is Not Implemented
+func (mo *MIDIOutput) WriteBatch(pulses []*Mt.PulseEvent) error {
+	return fmt.Errorf("not implemented")
+}
+
+// QueryRange is Not Implemented
+func (mo *MIDIOutput) QueryRange(start, end time.Time) ([]*Mt.PulseEvent, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/plugin/outputs-midi_test.go
+++ b/plugin/outputs-midi_test.go
@@ -1,0 +1,28 @@
+package plugin_test
+
+import (
+	"testing"
+	"time"
+
+	Mp "github.com/maroda/monteverdi/plugin"
+	Mt "github.com/maroda/monteverdi/types"
+)
+
+func TestMIDIOutput_WritePulse(t *testing.T) {
+	now := time.Now()
+	adapter, err := Mp.NewMIDIOutput(0)
+	assertError(t, err, nil)
+	defer adapter.Close()
+
+	t.Run("Plays one simple note from a pulse", func(t *testing.T) {
+		pulse := &Mt.PulseEvent{
+			Dimension: 1,
+			Metric:    []string{"NETWORK"},
+			Pattern:   0,
+			StartTime: now,
+			Duration:  4*time.Second + 200*time.Millisecond,
+		}
+
+		adapter.WritePulse(pulse)
+	})
+}

--- a/plugin/outputs-midi_test.go
+++ b/plugin/outputs-midi_test.go
@@ -1,28 +1,189 @@
 package plugin_test
 
 import (
+	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
 	Mp "github.com/maroda/monteverdi/plugin"
 	Mt "github.com/maroda/monteverdi/types"
+	"gitlab.com/gomidi/midi/v2"
 )
 
 func TestMIDIOutput_WritePulse(t *testing.T) {
-	now := time.Now()
+	// Use the MIDI adapter on the first port
 	adapter, err := Mp.NewMIDIOutput(0)
 	assertError(t, err, nil)
 	defer adapter.Close()
 
-	t.Run("Plays one simple note from a pulse", func(t *testing.T) {
+	t.Run("Returns Type", func(t *testing.T) {
+		if adapter.Type() != "MIDI" {
+			t.Error("Expected MIDI for Type()")
+		}
+	})
+
+	t.Run("Errors when NoteOn fails", func(t *testing.T) {
+		origSend := adapter.Send
+		// inject a SendNoteOnMIDI error
+		adapter.Send = func(msg midi.Message) error {
+			return fmt.Errorf("SendNoteOnMIDI error")
+		}
+		defer func() { adapter.Send = origSend }()
+
 		pulse := &Mt.PulseEvent{
 			Dimension: 1,
 			Metric:    []string{"NETWORK"},
 			Pattern:   0,
-			StartTime: now,
-			Duration:  4*time.Second + 200*time.Millisecond,
+			StartTime: time.Now(),
+			Duration:  100 * time.Millisecond,
+		}
+
+		// SendNoteOnMIDI is the first function for WritePulse
+		// the expected behavior is to return an error
+		// if SendNoteOnMIDI fails
+		err = adapter.WritePulse(pulse)
+		assertGotError(t, err)
+		adapter.WG.Wait()
+	})
+
+	t.Run("Flush method is correctly called", func(t *testing.T) {
+		flushCalled := false
+		originalSend := adapter.Send
+
+		// Wrap Send to detect Flush calls
+		adapter.Send = func(msg midi.Message) error {
+			flushCalled = true // We know we are calling Flush(), so set it to true
+			return originalSend(msg)
+		}
+
+		// Inject a NoteOff that always fails and will call Flush()
+		adapter.NoteOff = func(midic, midin uint8) error {
+			return fmt.Errorf("returns error")
+		}
+
+		pulse := &Mt.PulseEvent{
+			Dimension: 1,
+			Metric:    []string{"NETWORK"},
+			Pattern:   0,
+			StartTime: time.Now(),
+			Duration:  1 * time.Second,
 		}
 
 		adapter.WritePulse(pulse)
+		adapter.WG.Wait()
+
+		if !flushCalled {
+			t.Error("Expected flush to be called when NoteOff fails")
+		}
+
+		adapter.SendNoteOffMIDI(0, 62)
+	})
+}
+
+func TestMIDIOutput_ScaleStep(t *testing.T) {
+	adapter, err := Mp.NewMIDIOutput(0)
+	assertError(t, err, nil)
+	defer adapter.Close()
+
+	tests := []struct {
+		name  string
+		root  uint8
+		notes []uint8
+		steps []uint8
+	}{
+		{
+			"Returns the next member of the scale, C Diatonic Major",
+			60,
+			[]uint8{60, 62, 64, 65, 67, 69, 71, 72},
+			[]uint8{0, 2, 2, 1, 2, 2, 2, 1}, // This is also the default, diatonic major
+		},
+		{
+			"Returns the next member of the scale, D Diatonic Major",
+			62,
+			[]uint8{62, 64, 66, 67, 69, 71, 73, 74},
+			[]uint8{0, 2, 2, 1, 2, 2, 2, 1}, // diatonic major
+		},
+		{
+			"Returns the next member of the scale, D Natural Minor",
+			62,
+			[]uint8{62, 64, 65, 67, 69, 71, 72, 74},
+			[]uint8{0, 2, 1, 2, 2, 2, 1, 2}, // natural minor
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter.Scale = tt.steps
+			adapter.ScIdx = 0 // This should be incremented each time, only set it once
+			for i := 0; i < len(tt.steps); i++ {
+				if adapter.ScIdx != i {
+					t.Errorf("Expected Scale Index to self-increment to %d, got %d", i, adapter.ScIdx)
+				}
+
+				got := adapter.ScaleStep(tt.root)
+
+				if got != tt.notes[i] {
+					t.Errorf("Expected note to increment to %d, got %d", tt.notes[i], got)
+				}
+			}
+		})
+	}
+
+	t.Run("Wraps to the first member of the default scale", func(t *testing.T) {
+		root := uint8(60)
+		notes := []uint8{60, 62, 64, 65, 67, 69, 71, 72}
+		adapter.ScIdx = 0
+
+		// first step through all notes
+		for i := 0; i < len(adapter.Scale); i++ {
+			adapter.ScaleStep(root)
+		}
+
+		// now step one more and it should wrap
+		got := adapter.ScaleStep(root)
+		if got != notes[0] {
+			t.Errorf("Expected wrap to first note %d, got %d", notes[0], got)
+		}
+
+	})
+}
+
+// INTEGRATION: Audio confirmation through MIDI
+func TestMIDIOutput_ScaleAudio(t *testing.T) {
+	adapter, err := Mp.NewMIDIOutput(0)
+	assertError(t, err, nil)
+	defer adapter.Close()
+
+	t.Logf("outports:\n%s\n", midi.GetOutPorts())
+
+	t.Run("Plays five notes on a scale from five pulse events", func(t *testing.T) {
+		startTime := time.Now()
+		for i := 0; i < 5; i++ {
+			time.Sleep(time.Duration(rand.Intn(1000))*time.Millisecond + time.Second)
+			adapter.WritePulse(&Mt.PulseEvent{
+				Dimension: 1,
+				Metric:    []string{"NETWORK"},
+				Pattern:   0,
+				StartTime: startTime.Add(time.Duration(i) * time.Second),
+				Duration:  1 * time.Second,
+			})
+		}
+		adapter.WG.Wait()
+	})
+
+	t.Run("Plays 10 notes on a wrapped scale from 10 pulse events", func(t *testing.T) {
+		startTime := time.Now()
+		for i := 0; i < 10; i++ {
+			time.Sleep(time.Duration(rand.Intn(1000))*time.Millisecond + time.Second)
+			adapter.WritePulse(&Mt.PulseEvent{
+				Dimension: 1,
+				Metric:    []string{"NETWORK"},
+				Pattern:   0,
+				StartTime: startTime.Add(time.Duration(i) * time.Second),
+				Duration:  1 * time.Second,
+			})
+		}
+		adapter.WG.Wait()
 	})
 }


### PR DESCRIPTION
Now with the ability to have pulses trigger MIDI notes as an output.

The MIDIOutput plugin uses the same interface as the BadgerDB one and implements almost all the same methods (there is no way to Query an already fired MIDI event).

There is no distinction between types of pulse patterns yet. Notes that are played within 50ms of each other are automatically grouped and played as an arpeggio. Scale intervals are configurable and the notes are automatically derived. Other configurations include intervalic spacing and arpeggio delay times. This will automatically pick "port 0" for the MIDI device.

Tested through a Winterbloom Sol MIDI/CV interface driving a modular oscillator.